### PR TITLE
Fix vram leak when loading model

### DIFF
--- a/scripts/image_variations.py
+++ b/scripts/image_variations.py
@@ -19,7 +19,7 @@ from ldm.util import instantiate_from_config
 
 def load_model_from_config(config, ckpt, device, verbose=False):
     print(f"Loading model from {ckpt}")
-    pl_sd = torch.load(ckpt, map_location=device)
+    pl_sd = torch.load(ckpt, map_location='cpu')
     if "global_step" in pl_sd:
         print(f"Global Step: {pl_sd['global_step']}")
     sd = pl_sd["state_dict"]


### PR DESCRIPTION
When loading with the previous code, both pl_sd itself and the model read by state_dict from pl_sd are stored in vram, so the program consumes more graphics memory than it needs. Modify that part.