### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Currently it adds:
 
 ![banner-large.jpeg](https://s3.amazonaws.com/moonup/production/uploads/1674039767068-62bd5f951e22ec84279820e8.jpeg)
 
+[![Try a demo on Replicate](https://replicate.com/lambdal/image-mixer/badge)](https://replicate.com/lambdal/image-mixer)
+
 The model is available on [huggingface spaces](https://huggingface.co/spaces/lambdalabs/image-mixer-demo) or to run locally do the following:
 
 ```bash


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.